### PR TITLE
refactor(comment.py): remove filter for ezonets email for notif

### DIFF
--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -54,7 +54,7 @@ class Comment(Document):
 			sender_fullname = get_fullname(frappe.session.user)
 			title = get_title(self.reference_doctype, self.reference_name)
 
-			recipients = [frappe.db.get_value("User", {"enabled": 1, "name": name, "user_type": "System User", "allowed_in_mentions": 1, "email": ("not like", "%%esonetz.com")}, "email")
+			recipients = [frappe.db.get_value("User", {"enabled": 1, "name": name, "user_type": "System User", "allowed_in_mentions": 1}, "email")
 				for name in mentions]
 
 			notification_message = _('''{0} mentioned you in a comment in {1} {2}''')\


### PR DESCRIPTION
[Issue#4894](https://github.com/elexess/eso-newmatik/issues/4894)

I remove the filter since this is the reason why esonetz email domain doesn't get notification on the notification dropdown on the upper right. Regarding the email thing, this will also not send an email  since it was already filtered on this [PR](https://github.com/elexess/eso-newmatik/pull/4773/files) 

![esonetz](https://user-images.githubusercontent.com/40702858/133560513-ffa90e62-dc20-4e3a-849c-94a6e131fb2a.gif)
