### PR TITLE
fix(model.js): Add freeze message when renaming document

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -116,10 +116,13 @@ frappe.ui.form.Toolbar = Class.extend({
 				d.show();
 
 				d.set_primary_action(__("Rename"), function () {
+					d.hide();
 					let args = d.get_values();
 					if (args.title != me.frm.doc[title_field] || args.name != docname) {
 						frappe.call({
 							method: "frappe.model.rename_doc.update_document_title",
+							freeze: true,
+							freeze_message: "Updating related fields...",
 							args: {
 								doctype,
 								docname,

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -558,10 +558,13 @@ $.extend(frappe.model, {
 			]
 		});
 		d.set_primary_action(__("Rename"), function() {
+			d.hide();
 			var args = d.get_values();
 			if(!args) return;
 			return frappe.call({
 				method:"frappe.model.rename_doc.rename_doc",
+				freeze: true,
+				freeze_message: "Updating related fields...",
 				args: {
 					doctype: doctype,
 					old: docname,


### PR DESCRIPTION
Related Issue: [issue#1082](https://github.com/elexess/eso-beluga/issues/1082)

Problem
-
When renaming a document that is linked to multiple different fields, frappe automatically updates linked field values and renames dynamic links. However, if there is a large amount of links that need to be updated it may take some time. 

The problem is that there currently isn't any indication for the user that this process is occurring. 

When the rename button is clicked, nothing happens to inform the user that a background process is running and the button is disabled for a while until either the process finishes or the user clicks out/leaves the page.

![rename_problem](https://user-images.githubusercontent.com/84061770/141047798-278d3025-9da3-48d5-ace4-4c3399c0aa8d.gif)

This is a problem because if the user leaves the page/refreshes while the process is ongoing, it cuts it short and only a portion of the linked field values and dynamic links are updated.


Solution
-
The simplest solution I could think of would be to hide the dialog box after clicking rename and adding a *freeze* and *freeze_message* to the frappe.call that runs when the rename button is clicked.

Below is an example of what this looks like:

![proposed-solution](https://user-images.githubusercontent.com/84061770/141048267-68553d80-ac75-457d-ac08-6d7a7842712b.gif)

Notes
-
An issue was raised on core for this:
https://github.com/frappe/frappe/issues/14938
