### PR TITLE
fix:(communication.js):Overwrite Email Content on Selecting Email Template

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -259,11 +259,8 @@ frappe.views.CommunicationComposer = class {
 
 				const content_field = me.dialog.fields_dict.content;
 				const subject_field = me.dialog.fields_dict.subject;
-
-				let content = content_field.get_value() || "";
-				content = content.split('<!-- salutation-ends -->')[1] || content;
-
-				content_field.set_value(`${reply.message}<br>${content}`);
+				
+				content_field.set_value(reply.message);
 				subject_field.set_value(reply.subject);
 
 				me.reply_added = email_template;


### PR DESCRIPTION
[issue#5272](https://github.com/elexess/eso-newmatik/issues/5272)
### **Details of the Issue:**
When sending an email it allows user to choose an email template. However, when a user already loaded an email template and decides to change the template to another template, It does not overwrite the message with the newly selected template but instead it stacks it one after another.

### **Problem:**
The main issue is this should overwrite the message instead of stacking it one after another when selecting a new template as it is a logical standard behavior when selecting templates.

**Screenshot of the problem**
![before](https://user-images.githubusercontent.com/86836253/160337250-21a3f8ef-8bf5-4391-a2f2-6015c6b3ec0e.gif)


### **Replicate the Issue:**

- Menu > Email
- Choose Email Template
- Choose Another Email Template

### **Solution:**
Removing the line of code that keeps the previous template and adds it to the bottom of the new template.

**Screenshot of the fix:**
![after](https://user-images.githubusercontent.com/86836253/160337308-949e86af-a7de-48bb-b2d3-616af387fc2a.gif)

