### PR TITLE
Fix(__init__.py): able to rename item

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1189,6 +1189,7 @@ def rename_doc(*args, **kwargs):
 	"""
 	kwargs.pop("ignore_permissions", None)
 	kwargs.pop("cmd", None)
+	kwargs.pop("data", None)
 
 	from frappe.model.rename_doc import rename_doc
 


### PR DESCRIPTION
Issue: Unable to rename item
Solution: Catch the argument's that is being passed, then remove and return it with a None Value.

