### PR TITLE
feat:(communication.js):Email Template Filter

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -35,6 +35,26 @@ frappe.views.CommunicationComposer = class {
 		});
 
 		$(this.dialog.$wrapper.find(".form-section").get(0)).addClass('to_section');
+		$(this.dialog.$wrapper.find('div[data-fieldname ="language_filter"]').css({"float":"right", "margin-bottom": "0", "z-index": "1"}))
+		$(this.dialog.$wrapper.find('div[data-fieldname ="language_filter"] .checkbox').css({"margin-bottom": "0", "margin-top": "0" }))
+		$(this.dialog.$wrapper.find('div[data-fieldname ="language_filter"] .checkbox .help-box').remove())
+
+		me.dialog.fields_dict.language_filter.input.onclick = function() {
+			me.dialog_data = me.dialog.get_values();
+			if (me.dialog_data.language_filter == 1) {
+				me.dialog.fields_dict.email_template.get_query = function() {
+					return {
+						filters: {
+							'language': me.dialog_data.language_sel.substring(0,2)
+						}
+					}
+				}
+			} else {
+				me.dialog.fields_dict.email_template.get_query = function() {
+					return;
+				}
+			}
+		}
 
 		this.prepare();
 		this.dialog.show();
@@ -74,6 +94,11 @@ frappe.views.CommunicationComposer = class {
 				label: __("BCC"),
 				fieldtype: "MultiSelect",
 				fieldname: "bcc",
+			},
+			{
+				label: __("Print Language Filter"),
+				fieldtype: "Check",
+				fieldname: "language_filter"
 			},
 			{
 				label: __("Email Template"),
@@ -143,7 +168,6 @@ frappe.views.CommunicationComposer = class {
 				fieldname: "select_attachments"
 			}
 		];
-
 		// add from if user has access to multiple email accounts
 		const email_accounts = frappe.boot.email_accounts.filter(account => {
 			return (
@@ -174,7 +198,6 @@ frappe.views.CommunicationComposer = class {
 
 		return fields;
 	}
-
 	toggle_more_options(show_options) {
 		show_options = show_options || this.dialog.fields_dict.more_options.df.hidden;
 		this.dialog.set_df_property('more_options', 'hidden', !show_options);


### PR DESCRIPTION
Asana Link: https://app.asana.com/0/1202487840949165/1202489339704150/f

Issue: Customer notification sent in German, but the customer's language is English.

Solution:
I carried out the investigation according to your request and can conclude that this was a user error.

The way a notification is sent, is through frappe email feature, which then gives us the ability to choose on either English or Deutsch email template to send out to the customer. A proposal was made and approved about a new core feature in frappe for the email functionality. Which is to add a checkbox that when clicked it filters out all the email template that is based on the customer's language. The checkbox gives up a dynamic approach with regard to filtering. It gives us the capability of accessing all email templates and also minimizing it in accordance to the customer's language.


Screenshot:

For English Customers:
![email_template_english](https://user-images.githubusercontent.com/86836253/191676651-44049895-78b3-4cfb-b47c-af8c7c4b7752.gif)


For German Customers:
![email_template_de](https://user-images.githubusercontent.com/86836253/191676691-8b773629-58d2-4477-a5ed-7a064cf5886b.gif)