### PR TITLE
Fix(schema.py): Except TPUOM conversion field from alter query

### DIFF
--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -107,7 +107,8 @@ class MariaDBTable(DBTable):
 				if query_parts:
 					query_body = ", ".join(query_parts)
 					query = "ALTER TABLE `{}` {}".format(self.table_name, query_body)
-					frappe.db.sql(query)
+					if (not "tabTechnical Parameter UOM" in query) and (not "conversion" in query):
+						frappe.db.sql(query)
 
 		except Exception as e:
 			# sanitize


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202487840949173/1203323862208535/f

Issue: 
Base from this PR https://app.asana.com/0/1202487840949173/1203323862208535/f , I added an alter query for decimal precision for `conversion` field. But Frappe runs the alter query, that sets the default precision (21,9), every `bench migrate`. 

Solution: 
Added an exception for Conversion field from DocType Technical Parameter UOM to prevent from running the default alter query. 