### PR TITLE
feat:(form_timeline.js) HelpScout Indicator

### DIFF
--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -833,6 +833,7 @@ class FormTimeline extends BaseTimeline {
 		var email_bcc = []
 		var mime_type_list = []
 		var docname = this.frm.docname
+		var doctype = this.frm.doctype
 		if (!form_values) return;
 
 		const selected_attachments =
@@ -873,11 +874,18 @@ class FormTimeline extends BaseTimeline {
 							'reciever': form_values.recipients,
 							'mailbox': mailboxID,
 							'text': form_values.content,
+							'doctype': doctype,
+							'docname': docname,
 							'printf': docname,
 							'url': url_base64,
 							'cc': form_values.cc,
 							'bcc': form_values.bcc
 								},
+							callback(r) {
+								if (me.frm) {
+									me.frm.reload_doc();
+								}
+							}
 							});
 						}
 					}
@@ -890,11 +898,18 @@ class FormTimeline extends BaseTimeline {
 					'reciever': cur_dialog.fields_dict.recipients.value,
 					'mailbox': mailboxID,
 					'text': form_values.content,
+					'doctype': doctype,
+					'docname': docname,
 					'printf': docname,
 					'url': selected_attachments,
 					'cc': form_values.cc,
 					'bcc': form_values.bcc
 						},
+					callback(r) {
+						if (me.frm) {
+							me.frm.reload_doc();
+						}
+					}
 					});
 		}
 	}


### PR DESCRIPTION
As per Jeremy's request to add an indicator to when the Help Scout conversation has successfully been created.

I have also added a conversation link, so the user can easily navigate to the conversation they created.

Screenshot:
![HSC status indicator](https://user-images.githubusercontent.com/86836253/204963307-9403de73-d2bd-4e8a-b1d8-87cb2b948215.gif)
