### PR TITLE
feat(toolbar.js): remove comma when entering email in email modal

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -29,6 +29,9 @@ frappe.ui.form.Toolbar = class Toolbar {
 				this.print_icon && this.print_icon.removeClass("hide");
 			}
 		}
+
+		// trigger every form with Email menu
+		email_remove_last_comma()
 	}
 	set_title() {
 		if (this.frm.is_new()) {
@@ -577,3 +580,39 @@ frappe.ui.form.Toolbar = class Toolbar {
 		dialog.show();
 	}
 };
+
+
+function email_remove_last_comma(){
+	$("div.new-timeline").find("div.action-buttons").find("button.btn-secondary-dark.action-btn").on("click", function(){
+		remove_comma()
+	})
+
+	$('button[data-original-title="Menu"]').next("ul").find("li>a.grey-link.dropdown-item").on("click", function(){
+		remove_comma()
+	})
+
+}
+
+function remove_comma(){
+	setTimeout(function(){
+		if ($('.modal').hasClass("show") == true){
+			// this only called when there's "recipients, cc, bcc" field
+			$("input[data-fieldname='recipients']").on("change", function(){
+				slice_val(this)
+			})
+			$("input[data-fieldname='cc']").on("change", function(){
+				slice_val(this)
+			})
+			$("input[data-fieldname='bcc']").on("change", function(){
+				slice_val(this)
+			})
+		}
+	}, 500)
+
+	let slice_val = (obj) => {
+		if (obj.value.slice(-2 )== ", "){
+			var newval = obj.value.slice(0,-2)
+			obj.value = newval
+		}
+	}
+}


### PR DESCRIPTION
Ref: https://app.asana.com/0/1202487840949165/1203498527287716/f

Request: 
Remove comma when entering an email from Email modal so that the user don't have to erase the comma everytime they input the an email

Solution:
Added DOM in toolbar.js so that it will always trigger in every form every refresh. This feature applies on every Menu dropdown (... from upper left) and in New Email button in footer

Result: 
![email-comma](https://user-images.githubusercontent.com/36461178/208007558-2ce29cc2-2025-4282-a018-f5fd956ecb80.gif)
