### PR TITLE
feat(assign_to.js): Filter to only show eso employee only

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/assign_to.js
+++ b/frappe/public/js/frappe/form/sidebar/assign_to.js
@@ -146,7 +146,7 @@ frappe.ui.form.AssignToDialog = Class.extend({
 	},
 	get_fields: function() {
 		let me = this;
-
+		var employee
 		return [
 			{
 				label: __("Assign to me"),
@@ -161,7 +161,33 @@ frappe.ui.form.AssignToDialog = Class.extend({
 				label: __("Assign To"),
 				reqd: true,
 				get_data: function(txt) {
-					return frappe.db.get_link_options("User", txt, {user_type: "System User", enabled: 1});
+					let eso_electronic = frappe.db.get_link_options("User", txt, {
+						user_type: "System User", 
+						enabled: 1,
+						name: ['like', '%eso_electronic.com']
+					});
+					
+					let newmatik = frappe.db.get_link_options("User", txt, {
+						user_type: "System User", 
+						enabled: 1,
+						name: ['like', '%newmatik.com']
+					});
+
+					let esonetz = frappe.db.get_link_options("User", txt, {
+						user_type: "System User", 
+						enabled: 1,
+						name: ['like', '%esonetz.com']
+					});
+
+					const employee_list = Promise.all([eso_electronic, newmatik, esonetz]).then(function(result) {
+						const combined = result.reduce((acc, result) => { 
+							return acc.concat(result)
+						 }, [])
+						
+						return combined
+						
+					});
+					return employee_list
 				}
 			},
 			{


### PR DESCRIPTION
Asana Link: https://app.asana.com/0/1202487840949173/1203653658334473/f

Feature Request: 
For every DocType, there is an "Assigned To" field that can be used to notify users about new tasks. However, the list allows anyone to select from the whole 'User' list.

This is a risk because there are users registered in the system for customers for their Newmatik portal access.

With this, the suggestion is to filter the Assigned To field to only allow ESO domain users to be selected.

Expected Result:
The field should be filtered to ESO accounts only
@eso-electronic.com
@newmatik.com
@esonetz.com

Screenshot:
![testetestest](https://user-images.githubusercontent.com/86836253/210974656-2bc5014d-2cb0-4e9b-b822-931083f3b19e.gif)
