### PR TITLE
feat(auth.py): Restrict non ESO employees to login in ERP

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -20,6 +20,7 @@ from frappe.twofactor import (
 from frappe.utils import cint, date_diff, datetime, get_datetime, today
 from frappe.utils.password import check_password
 from frappe.website.utils import get_home_page
+import re
 
 
 class HTTPRequest:
@@ -155,7 +156,14 @@ class LoginManager:
 			if not confirm_otp_token(self):
 				return False
 		frappe.form_dict.pop("pwd", None)
-		self.post_login()
+
+		has_next_role = frappe.db.exists("Has Role", {"parent": self.user, "role": ["in", ["NEXT Super User", "Next Standard User"]]})
+		if not re.search('@newmatik.com|@esonetz.com|@eso-electronic.com|Administrator', self.user):
+			if has_next_role:
+				frappe.msgprint("User Access Not Allowed")
+				return False
+		else:
+			self.post_login()
 
 	def post_login(self):
 		self.run_trigger("on_login")


### PR DESCRIPTION
### Restrict access on logging in to ERP
-----
Reference: [Asana Link](https://app.asana.com/0/1202487840949165/1203856408315555/f)

**Only allow emails that have the following domains to access ERP:** _newmatik.com, esonetz.com, eso-electronic.com_ 


https://user-images.githubusercontent.com/58759735/220827457-6fdf80e9-8c52-44e2-9e00-08e56c7e9419.mp4

