### PR TITLE
fix(query_report.js): Exclude Kitting on Preparing report modal

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -134,16 +134,27 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.menu_items = this.get_menu_items();
 		this.datatable = null;
 		this.prepared_report_action = "New";
-
-		frappe.run_serially([
-			() => this.get_report_doc(),
-			() => this.get_report_settings(),
-			() => this.setup_progress_bar(),
-			() => this.setup_page_head(),
-			() => this.refresh_report(route_options),
-			() => this.add_chart_buttons_to_toolbar(true),
-			() => this.add_card_button_to_toolbar(true),
-		]);
+		if(this.report_name == "Kitting") {
+			frappe.run_serially([
+				() => this.get_report_doc(),
+				() => this.get_report_settings(),
+				() => this.setup_page_head(),
+				() => this.refresh_report(route_options),
+				() => this.add_chart_buttons_to_toolbar(true),
+				() => this.add_card_button_to_toolbar(true),
+			]);
+		} else {
+			frappe.run_serially([
+				() => this.get_report_doc(),
+				() => this.get_report_settings(),
+				() => this.setup_progress_bar(),
+				() => this.setup_page_head(),
+				() => this.refresh_report(route_options),
+				() => this.add_chart_buttons_to_toolbar(true),
+				() => this.add_card_button_to_toolbar(true),
+			]);
+		}
+		
 	}
 
 	add_card_button_to_toolbar() {


### PR DESCRIPTION
Asana Link: https://app.asana.com/0/1202487840949165/1203570309632109/f

Fix: Due to high volume of data that is being processed inside the kitting report, the prepared report modal gets stuck on progress. To fix this, we will exclude the Kitting report to not show the preparing report progress bar.


Screenshot:
![kittinghggg](https://user-images.githubusercontent.com/86836253/221772652-f90f0737-74f6-4232-bdb2-69114823e925.gif)

