### PR TITLE
fix(global and checkbox.scss): Inconsistent Checkbox sizes on long text

### DIFF
--- a/frappe/public/scss/common/global.scss
+++ b/frappe/public/scss/common/global.scss
@@ -8,7 +8,7 @@ html, body {
 /* checkbox */
 .checkbox {
 	label {
-		display: inline-flex;
+		display: inline-block;
 		align-items: center;
 		margin-bottom: 0;
 	}

--- a/frappe/public/scss/element/checkbox.scss
+++ b/frappe/public/scss/element/checkbox.scss
@@ -1,6 +1,7 @@
 $check-icon: url("data:image/svg+xml, <svg viewBox='0 0 8 7' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M1 4.00001L2.66667 5.80001L7 1.20001' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 
 input[type="checkbox"] {
+	vertical-align: middle;
 	position: relative;
 	width: var(--checkbox-size) !important;
 	height: var(--checkbox-size);


### PR DESCRIPTION
Help Scout UI Fixes && Core Fix
Issue reported by Dominik through Help Scout: Inconsistent Checkbox sizes

During investigation, I noticed that this isn't just happening to the help scout dialogue but also affect other modals like the email modal

Before:
![checkbox_before](https://user-images.githubusercontent.com/86836253/224610918-89d29f46-95b8-49a0-8f99-b20b1ce3d52f.gif)


After:
![checkbox_after](https://user-images.githubusercontent.com/86836253/224610945-54bb08dc-2fd8-4e44-8c5f-3961332b743d.gif)

