### PR TITLE
fix(rename_doc.py): replace frappe.db.set_value to update sql

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -350,7 +350,9 @@ def update_link_field_values(link_fields, old, new, doctype):
 			if parent == new and doctype == "DocType":
 				parent = old
 
-			frappe.db.set_value(parent, {docfield: old}, docfield, new, update_modified=False)
+			# frappe.db.set_value(parent, {docfield: old}, docfield, new, update_modified=False)
+			# replace to update sql to minimize select and update query -- eso custom
+			frappe.db.sql("UPDATE `tab{}` set {}='{}' WHERE {}='{}' ".format(parent, docfield, new, docfield, old))
 
 		# update cached link_fields as per new
 		if doctype == "DocType" and field["parent"] == old:


### PR DESCRIPTION
Asana: https://app.asana.com/0/1202487840949165/1204163982618361/f

**Request**:
Update user's email.

**Issue**:
the Request Time Out pops up when renaming the user's account because it has a lot of related links that are connected

**Probable Solution**:
Replace the frappe.db.set_value to Update SQL so that it will directly update the related links and not to call a select query first then update.
