### PR TITLE
fix(query_report.py): export excel

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -348,10 +348,6 @@ def export_query():
 		xlsx_data = build_xlsx_data(columns, data, visible_idx, include_indentation)
 		xlsx_file = make_xlsx(xlsx_data, "Query Report")
 
-		data["result"] = handle_duration_fieldtype_values(data.get("result"), data.get("columns"))
-		xlsx_data, column_widths = build_xlsx_data(columns, data, visible_idx, include_indentation)
-		xlsx_file = make_xlsx(xlsx_data, "Query Report", column_widths=column_widths)
-
 		frappe.response["filename"] = report_name + ".xlsx"
 		frappe.response["filecontent"] = xlsx_file.getvalue()
 		frappe.response["type"] = "binary"


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1204175327624880/f

Issue:
Error on exporting an excel from query report type. The version update affected the code and was merged.

Solution:
Compared our current repository vs the main and fix. 

Result:
![bomexportreport](https://user-images.githubusercontent.com/36461178/226227767-a91add92-451c-4032-9fb2-2aae480d2604.gif)
