### PR TITLE
fix(helpscout: form_timeline.js): Fix inconsitent checkbox sizes

### DIFF
--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -780,8 +780,9 @@ class FormTimeline extends BaseTimeline {
 
 	get_attachment_row(attachment, checked) {
 		return $(`<p class="checkbox flex">
-			<label class="ellipsis" title="${attachment.file_name}">
+			<label style="display: block; !important" class="ellipsis" title="${attachment.file_name}">
 				<input
+					style="display: inline-block; vertical-align: middle;"
 					type="checkbox"
 					data-file-name="${attachment.name}"
 					data-tile="${attachment.file_name}"


### PR DESCRIPTION
Reference: https://secure.helpscout.net/conversation/2096079488/176521?folderId=6882823

Issue: In the attachment list section whenever a checkbox has a long label the checkbox shrinks.

Solution: Responsive Checkboxes, by making the checkboxes display on block and the label display on inline-block

Before:
![Material request for WO-DE-22-00247-ST - MREQ-0093bbb](https://user-images.githubusercontent.com/86836253/235089650-c78da09b-ba4b-426d-a55a-a9eecd4c75bd.png)


After:
![Material request for WO-DE-22-00247-ST - MREQ-0093](https://user-images.githubusercontent.com/86836253/235089671-2ec07e1f-5a9f-493f-95ca-84e6dbbcd7d0.png)
