### PR TITLE
feat(print_utils.js): set Kitting Report Print Orientation

### DIFF
--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -33,7 +33,7 @@ frappe.ui.get_print_settings = function(
 				{ value: "Landscape", label: __("Landscape") },
 				{ value: "Portrait", label: __("Portrait") }
 			],
-			default: "Landscape"
+			default: frappe.query_report && frappe.query_report.page_name === "query-report/Kitting" ? "Portrait" : "Landscape"
 		}
 	];
 


### PR DESCRIPTION
**Reference:** [Kitting Report Task Asana Link](https://app.asana.com/0/1202487840949173/1205157644017535/f)

Set default Print Settings Orientation to "Portrait" by adding validation whenever Kitting Report is the current route when printing.

**Attached below is a sample as a reference:**

https://github.com/elexess/eso-frappe/assets/58759735/bcde4c0c-8533-40d8-9a38-ef6f09c535b4

