### PR TITLE
feat(workflow.py): allow documents to be set back to draft

### DIFF
--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -106,12 +106,13 @@ class Workflow(Document):
 					frappe._("Cannot change state of Cancelled Document. Transition row {0}").format(t.idx)
 				)
 
-			if state.doc_status == "1" and next_state.doc_status == "0":
-				frappe.throw(
-					frappe._("Submitted Document cannot be converted back to draft. Transition row {0}").format(
-						t.idx
-					)
-				)
+			# Comment out because at Newmatik, we want to be able to set a Submitted document back to Draft regardless if it has succeeding transactions
+			# if state.doc_status == "1" and next_state.doc_status == "0":
+			# 	frappe.throw(
+			# 		frappe._("Submitted Document cannot be converted back to draft. Transition row {0}").format(
+			# 			t.idx
+			# 		)
+			# 	)
 
 			if state.doc_status == "0" and next_state.doc_status == "2":
 				frappe.throw(frappe._("Cannot cancel before submitting. See Transition {0}").format(t.idx))


### PR DESCRIPTION
### Message from Carly via MS Teams:
> Hey Jeremy, we for some reason do not have the status option to move an approved PO back to DRAFT status. Can you please add this back in ASAP? The only option right now is "Sent" and we need to be able to move approved POs back if there is an issue.

### Changes
The main reason why we do not have the status option to move an approved PO back to Draft status is because ERPNext's original workflow assumes that the user workflows are linear and flows from Draft to Submitted and can only go back to Draft once a document is cancelled and amended. This is so that succeeding transactions (if any, e.g. Purchase Invoices, Purchase Receipts) do not get tangled up at the database-level.

At Newmatik, the details tend to be dynamic. Thus, we utilize a "Custom Workflow" actions as a workaround to ERPNext's framework. However, we still cannot set any document from Submitted back to Draft (without Cancelling) using Workflow because of a core validation.

With this, we need to remove the Core Validation to achieve the user's wishes.