### PR TITLE
feat: add bypass_unsubscribe parameter for sendmail

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -609,6 +609,7 @@ def sendmail(
 	header=None,
 	print_letterhead=False,
 	with_container=False,
+	bypass_unsubscribe=False,
 ):
 	"""Send email using user's default **Email Account** or global default **Email Account**.
 
@@ -636,6 +637,7 @@ def sendmail(
 	:param args: Arguments for rendering the template
 	:param header: Append header in email
 	:param with_container: Wraps email inside a styled container
+	:param bypass_unsubscribe: Bypass unsubscribe link
 	"""
 
 	if recipients is None:
@@ -691,6 +693,7 @@ def sendmail(
 		header=header,
 		print_letterhead=print_letterhead,
 		with_container=with_container,
+		bypass_unsubscribe=bypass_unsubscribe,
 	)
 
 

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -66,6 +66,7 @@ def send(
 	header=None,
 	print_letterhead=False,
 	with_container=False,
+	bypass_unsubscribe=False,
 ):
 	"""Add email to sending queue (Email Queue)
 
@@ -91,6 +92,7 @@ def send(
 	:param inline_images: List of inline images as {"filename", "filecontent"}. All src properties will be replaced with random Content-Id
 	:param header: Append header in email (boolean)
 	:param with_container: Wraps email inside styled container
+	:param bypass_unsubscribe: Bypass unsubscribe check
 	"""
 	if not unsubscribe_method:
 		unsubscribe_method = "/api/method/frappe.email.queue.unsubscribe"
@@ -130,8 +132,11 @@ def send(
 
 	all_ids = tuple(recipients + cc)
 
-	unsubscribed = frappe.db.sql_list(
-		"""
+	if bypass_unsubscribe:
+		unsubscribed = []
+	else:
+		unsubscribed = frappe.db.sql_list(
+			"""
 		SELECT
 			distinct email
 		from


### PR DESCRIPTION
Related to https://github.com/newmatik/next3/issues/256#issuecomment-2710260837

## Changes
- Add `bypass_unsubscribe` parameter to the send email function of Frappe.
- If true, then it should not check and exclude any emails from `tabEmail Unsubscribe`. This is useful so that users can still receive emails even if they have an entry in the table with global unsubscribe.
- For example, emails like account verification or password reset will get skipped if they have unsubscribed, but with bypass_unsubscribe, then they should still receive an email.

https://github.com/user-attachments/assets/4a04e5ca-4d3b-49fa-97bf-98ca99076ae1

Showing received email:
<img width="2043" alt="image" src="https://github.com/user-attachments/assets/e73ab2aa-2dde-49dc-bd39-5b14bfaff1bc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the email sending process by introducing an option to disable the inclusion of the unsubscribe link, allowing more flexibility in email communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->