### PR TITLE
revert(assign_to.js): Remove core code filtering users to assign to

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/assign_to.js
+++ b/frappe/public/js/frappe/form/sidebar/assign_to.js
@@ -146,7 +146,7 @@ frappe.ui.form.AssignToDialog = Class.extend({
 	},
 	get_fields: function() {
 		let me = this;
-		var employee
+
 		return [
 			{
 				label: __("Assign to me"),
@@ -161,33 +161,7 @@ frappe.ui.form.AssignToDialog = Class.extend({
 				label: __("Assign To"),
 				reqd: true,
 				get_data: function(txt) {
-					let eso_electronic = frappe.db.get_link_options("User", txt, {
-						user_type: "System User", 
-						enabled: 1,
-						name: ['like', '%eso_electronic.com']
-					});
-					
-					let newmatik = frappe.db.get_link_options("User", txt, {
-						user_type: "System User", 
-						enabled: 1,
-						name: ['like', '%newmatik.com']
-					});
-
-					let esonetz = frappe.db.get_link_options("User", txt, {
-						user_type: "System User", 
-						enabled: 1,
-						name: ['like', '%esonetz.com']
-					});
-
-					const employee_list = Promise.all([eso_electronic, newmatik, esonetz]).then(function(result) {
-						const combined = result.reduce((acc, result) => { 
-							return acc.concat(result)
-						 }, [])
-						
-						return combined
-						
-					});
-					return employee_list
+					return frappe.db.get_link_options("User", txt, {user_type: "System User", enabled: 1});
 				}
 			},
 			{


### PR DESCRIPTION
re: No asana task.

Changes:
--
Reverting (https://github.com/newmatik/eso-frappe/commit/b5cb7f3663f55bc25e8559b5ea58f5fa88ff3a33) core changes to filter only employee emails ending in (eso_electronic.com, newmatik.com, esonetz.com)

Reason:
-- 
Adding changes in Newmatik Custom Application to clean up frappe core code for easier migration to future versions.

I'll be creating a new PR for Newmatik to implement this feature again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined “Assign To” user search to use a single, unified source of enabled system users, removing domain-specific lookups and redundant merging.
- **Bug Fixes**
  - Assignee suggestions now consistently include all enabled system users, avoiding omissions caused by previous domain-based filtering.
  - Faster and more reliable population of user options in the assignment dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->