### PR TITLE
ref: add fallback logic for navbar logo

### DIFF
--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -36,7 +36,7 @@ class NavbarSettings(Document):
 def get_app_logo():
 	app_logo = frappe.db.get_single_value("Navbar Settings", "app_logo", cache=True)
 	if not app_logo:
-		app_logo = frappe.get_hooks("app_logo_url")[-1]
+		app_logo = frappe.get_hooks("navbar_logo_url")[-1] or frappe.get_hooks("app_logo_url")[-1]
 
 	return app_logo
 


### PR DESCRIPTION
re https://app.asana.com/1/5641712848301/project/1202488269220482/task/1211243554826373

Issue:
--
In the hooks config, app_logo_url sets both logo for login page and the desk page (top-left logo). We want it different for both. 

Fix:
--
Adding new hook config for navbar logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navbar logo selection. When no app logo is configured, the navbar now prefers the Navbar Logo setting and, if unavailable, falls back to the App Logo URL. This ensures consistent branding, reduces cases of missing/incorrect logos, and aligns the displayed logo with user-configured preferences without requiring any action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->