### PR TITLE
fix: bypass permission for private user profile image

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -788,6 +788,8 @@ def has_permission(doc, ptype=None, user=None):
 					)
 			else:
 				has_access = ref_doc.has_permission("read")
+				# This is a special case for user image field.
+				# This is to allow users to see the assignee's image in sidebar and list view.
 				if attached_to_doctype == "User" and doc.attached_to_field == "user_image":
 					has_access = True
 

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -778,7 +778,6 @@ def has_permission(doc, ptype=None, user=None):
 			ref_doc = frappe.get_doc(attached_to_doctype, attached_to_name)
 
 			if ptype in ["write", "create", "delete"]:
-				has_access = ref_doc.has_permission("write")
 
 				if ptype == "delete" and not has_access:
 					frappe.throw(
@@ -789,6 +788,9 @@ def has_permission(doc, ptype=None, user=None):
 					)
 			else:
 				has_access = ref_doc.has_permission("read")
+				if attached_to_doctype == "User" and doc.attached_to_field == "user_image":
+					has_access = True
+
 		except frappe.DoesNotExistError:
 			# if parent doc is not created before file is created
 			# we cannot check its permission so we will use file's permission


### PR DESCRIPTION
Ref: https://app.asana.com/1/5641712848301/project/1203283251131831/task/1212856119282207?focus=true

**Issue:**
User cannot see the assignee's profile image makes it a hassle to identify who is/are the assigned in the certain document.
_Reason:_ User Profile images are stored as `private`. Permission (403) Error upon accessing image even having the "All" role with "read" permission
<img width="656" height="128" alt="image" src="https://github.com/user-attachments/assets/d37bd464-a8d2-46ac-9d29-856e783b92bb" />
<img width="803" height="379" alt="image" src="https://github.com/user-attachments/assets/8af2f6a6-8644-4f4e-82c7-c600aa3915ad" />

**Fix:**
Bypass permission only for the user profile images.
<img width="750" height="455" alt="image" src="https://github.com/user-attachments/assets/9fc1c711-5242-4c89-8d51-a1528441ad42" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachment permission checks now validate read (view) access instead of write for linked documents, preventing unnecessary denials.
  * Uploading profile images to user accounts is now allowed in the expected cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->