### PR TITLE
fix(background_jobs): catch QueryDeadlockError and QueryTimeoutError in execute_job retry logic

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -146,11 +146,13 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 	try:
 		retval = method(**kwargs)
 
-	except (frappe.db.InternalError, frappe.RetryBackgroundJobError) as e:
+	except (frappe.db.InternalError, frappe.RetryBackgroundJobError,
+			frappe.QueryDeadlockError, frappe.QueryTimeoutError) as e:
 		frappe.db.rollback()
 
 		if retry < 5 and (
 			isinstance(e, frappe.RetryBackgroundJobError)
+			or isinstance(e, (frappe.QueryDeadlockError, frappe.QueryTimeoutError))
 			or (frappe.db.is_deadlocked(e) or frappe.db.is_timedout(e))
 		):
 			# retry the job if


### PR DESCRIPTION
## Summary

- Fixes a bug where MySQL deadlock (1213) and timeout (1205) errors in background jobs are never retried, despite retry logic being present in `execute_job`.
- `database.py` wraps these as `QueryDeadlockError` / `QueryTimeoutError` (inheriting from `Exception`), but `execute_job` only catches `db.InternalError` (`pymysql.err.InternalError`). The wrapped exceptions fall through to the generic handler and produce Error Log entries instead of being retried.
- Adds both exception types to the `except` clause and retry condition, enabling the existing retry-with-backoff (up to 5 attempts with 1-5s delay) to work as originally intended.

**Note**: This same bug exists in upstream Frappe v15 and the v16 `develop` branch.

## Test plan

- [ ] Deploy to staging and trigger a concurrent document deletion scenario (e.g., bulk delete of File Share records)
- [ ] Verify that transient deadlocks are retried silently (no Error Log entries) instead of failing
- [ ] Verify that persistent errors (non-deadlock) still fail and log correctly after 5 retries

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved background job reliability by enabling automatic retries for database deadlock and timeout errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->